### PR TITLE
Empty Drive trash and scope image cleanup to owned files

### DIFF
--- a/tests/test_thread_offload.py
+++ b/tests/test_thread_offload.py
@@ -56,6 +56,7 @@ class TestBlockingCallsOffloaded:
         mock_to_thread.side_effect = [
             (mock_slides_svc, mock_drive_svc),  # get_google_services
             None,         # delete_old_images
+            None,         # empty_trash
             "named_id",   # copy_presentation (named)
             "anon_id",    # copy_presentation (anon)
             None,         # share_presentation (named)
@@ -84,11 +85,12 @@ class TestBlockingCallsOffloaded:
         await generate_slides(mock_client)
 
         # Verify to_thread was called for each blocking operation
-        assert mock_to_thread.await_count == 10
+        assert mock_to_thread.await_count == 11
         called_funcs = [c.args[0].__name__ for c in mock_to_thread.call_args_list]
         assert called_funcs == [
             "get_google_services",
             "delete_old_images",
+            "empty_trash",
             "copy_presentation",
             "copy_presentation",
             "share_presentation",

--- a/weekly_slides_bot.py
+++ b/weekly_slides_bot.py
@@ -446,11 +446,14 @@ def delete_drive_file(drive_svc, file_id: str) -> None:
 
 
 def delete_old_images(drive_svc) -> None:
-    """Delete all 'submission_image' files from the Drive folder."""
+    """Delete all 'submission_image' files owned by us from the Drive folder."""
     if not DRIVE_FOLDER_ID:
         return
     try:
-        query = f"name = 'submission_image' and '{DRIVE_FOLDER_ID}' in parents and trashed = false"
+        query = (
+            f"name = 'submission_image' and '{DRIVE_FOLDER_ID}' in parents "
+            f"and trashed = false and 'me' in owners"
+        )
         resp = execute_with_retry(
             drive_svc.files().list(q=query, fields="files(id)", pageSize=1000)
         )
@@ -462,6 +465,15 @@ def delete_old_images(drive_svc) -> None:
             delete_drive_file(drive_svc, f["id"])
     except Exception as exc:  # noqa: BLE001
         print(f"[warn] Could not clean up old images: {exc}")
+
+
+def empty_trash(drive_svc) -> None:
+    """Permanently delete all trashed files to free Drive quota."""
+    try:
+        execute_with_retry(drive_svc.files().emptyTrash())
+        print("[info] Emptied Drive trash.")
+    except Exception as exc:  # noqa: BLE001
+        print(f"[warn] Could not empty Drive trash: {exc}")
 
 
 def presentation_url(pres_id: str) -> str:
@@ -1554,6 +1566,7 @@ async def generate_slides(client: discord.Client) -> None:
         if anon_pres_id:
             await asyncio.to_thread(delete_drive_file, drive_svc, anon_pres_id)
         await asyncio.to_thread(delete_old_images, drive_svc)
+        await asyncio.to_thread(empty_trash, drive_svc)
         try:
             named_pres_id = await asyncio.to_thread(copy_presentation, drive_svc, f"Guess Chat — {topic} (Named)")
             anon_pres_id = await asyncio.to_thread(copy_presentation, drive_svc, f"Guess Chat — {topic} (Anonymous)")


### PR DESCRIPTION
- Filter delete_old_images query to 'me' in owners so it only tries to delete files the service account owns (avoids insufficientFilePermissions errors on files created by other credentials)
- Add empty_trash() call after cleanup to permanently free quota space (deleted files stay in trash for 30 days and still count against quota)

Fixes #68

https://claude.ai/code/session_016fWEfMDyeSQw8aAwUwd4LR