### PR TITLE
Add exponential backoff retry for Google Drive quota errors

### DIFF
--- a/tests/test_quota_retry.py
+++ b/tests/test_quota_retry.py
@@ -1,0 +1,92 @@
+"""Tests for copy_presentation_with_quota_retry backoff behaviour."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Provide required env vars before importing the module
+os.environ.setdefault("DISCORD_TOKEN", "test")
+os.environ.setdefault("DISCORD_CHANNEL_ID", "1")
+os.environ.setdefault("DISCORD_RESULTS_CHANNEL_ID", "2")
+os.environ.setdefault("TEMPLATE_DECK_ID", "tpl")
+
+from weekly_slides_bot import StorageQuotaExceededError, copy_presentation_with_quota_retry
+
+
+class TestCopyPresentationWithQuotaRetry:
+    """copy_presentation_with_quota_retry retries on quota errors with backoff."""
+
+    @patch("weekly_slides_bot.copy_presentation", return_value="new-id")
+    def test_returns_id_on_first_success(self, mock_copy):
+        drive_svc = MagicMock()
+        result = copy_presentation_with_quota_retry(drive_svc, "My Title")
+        assert result == "new-id"
+        mock_copy.assert_called_once_with(drive_svc, "My Title")
+
+    @patch("weekly_slides_bot.time.sleep")
+    @patch(
+        "weekly_slides_bot.copy_presentation",
+        side_effect=[StorageQuotaExceededError("quota"), "recovered-id"],
+    )
+    def test_retries_once_on_quota_error(self, mock_copy, mock_sleep):
+        drive_svc = MagicMock()
+        result = copy_presentation_with_quota_retry(drive_svc, "Title", max_retries=4)
+        assert result == "recovered-id"
+        assert mock_copy.call_count == 2
+        mock_sleep.assert_called_once_with(2)  # 2^1 = 2 seconds
+
+    @patch("weekly_slides_bot.time.sleep")
+    @patch(
+        "weekly_slides_bot.copy_presentation",
+        side_effect=[
+            StorageQuotaExceededError("quota"),
+            StorageQuotaExceededError("quota"),
+            "recovered-id",
+        ],
+    )
+    def test_retries_multiple_times_with_exponential_backoff(self, mock_copy, mock_sleep):
+        drive_svc = MagicMock()
+        result = copy_presentation_with_quota_retry(drive_svc, "Title", max_retries=4)
+        assert result == "recovered-id"
+        assert mock_copy.call_count == 3
+        waits = [c.args[0] for c in mock_sleep.call_args_list]
+        assert waits == [2, 4]  # 2^1, 2^2
+
+    @patch("weekly_slides_bot.time.sleep")
+    @patch(
+        "weekly_slides_bot.copy_presentation",
+        side_effect=StorageQuotaExceededError("quota"),
+    )
+    def test_raises_after_max_retries_exhausted(self, mock_copy, mock_sleep):
+        drive_svc = MagicMock()
+        with pytest.raises(StorageQuotaExceededError):
+            copy_presentation_with_quota_retry(drive_svc, "Title", max_retries=2)
+        assert mock_copy.call_count == 3  # 1 initial + 2 retries
+        assert mock_sleep.call_count == 2
+
+    @patch("weekly_slides_bot.time.sleep")
+    @patch(
+        "weekly_slides_bot.copy_presentation",
+        side_effect=StorageQuotaExceededError("quota"),
+    )
+    def test_backoff_sequence_for_max_retries_4(self, mock_copy, mock_sleep):
+        drive_svc = MagicMock()
+        with pytest.raises(StorageQuotaExceededError):
+            copy_presentation_with_quota_retry(drive_svc, "Title", max_retries=4)
+        waits = [c.args[0] for c in mock_sleep.call_args_list]
+        assert waits == [2, 4, 8, 16]  # 2^1 through 2^4
+
+    @patch("weekly_slides_bot.time.sleep")
+    @patch(
+        "weekly_slides_bot.copy_presentation",
+        side_effect=[StorageQuotaExceededError("quota"), RuntimeError("other error")],
+    )
+    def test_non_quota_errors_propagate_immediately(self, mock_copy, mock_sleep):
+        drive_svc = MagicMock()
+        with pytest.raises(RuntimeError, match="other error"):
+            copy_presentation_with_quota_retry(drive_svc, "Title", max_retries=4)
+        assert mock_copy.call_count == 2
+        mock_sleep.assert_called_once()  # slept after first (quota) failure only

--- a/weekly_slides_bot.py
+++ b/weekly_slides_bot.py
@@ -425,6 +425,29 @@ def copy_presentation(drive_svc, title: str) -> str:
     return result["id"]
 
 
+def copy_presentation_with_quota_retry(
+    drive_svc, title: str, max_retries: int = 4
+) -> str:
+    """Copy the template deck, retrying with backoff on quota errors.
+
+    Google Drive quota may not update immediately after emptying trash.
+    Retrying with exponential backoff gives the quota time to propagate.
+    """
+    for attempt in range(max_retries + 1):
+        try:
+            return copy_presentation(drive_svc, title)
+        except StorageQuotaExceededError:
+            if attempt == max_retries:
+                raise
+            wait = 2 ** (attempt + 1)  # 2, 4, 8, 16 seconds
+            print(
+                f"[warn] Storage quota exceeded after trash empty; "
+                f"retrying in {wait}s (attempt {attempt + 1}/{max_retries})"
+            )
+            time.sleep(wait)
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
 def share_presentation(drive_svc, file_id: str) -> None:
     """Share presentation as anyone-with-link editor."""
     execute_with_retry(
@@ -1568,8 +1591,8 @@ async def generate_slides(client: discord.Client) -> None:
         await asyncio.to_thread(delete_old_images, drive_svc)
         await asyncio.to_thread(empty_trash, drive_svc)
         try:
-            named_pres_id = await asyncio.to_thread(copy_presentation, drive_svc, f"Guess Chat — {topic} (Named)")
-            anon_pres_id = await asyncio.to_thread(copy_presentation, drive_svc, f"Guess Chat — {topic} (Anonymous)")
+            named_pres_id = await asyncio.to_thread(copy_presentation_with_quota_retry, drive_svc, f"Guess Chat — {topic} (Named)")
+            anon_pres_id = await asyncio.to_thread(copy_presentation_with_quota_retry, drive_svc, f"Guess Chat — {topic} (Anonymous)")
         except StorageQuotaExceededError:
             print("[error] Google Drive storage quota exceeded — cannot create new decks.")
             notify_channel = None


### PR DESCRIPTION
## Summary
Adds a new `copy_presentation_with_quota_retry()` function that wraps the existing `copy_presentation()` call with exponential backoff retry logic to handle transient Google Drive storage quota errors. This addresses the issue where quota may not update immediately after emptying trash.

## Key Changes
- **New function `copy_presentation_with_quota_retry()`**: Implements exponential backoff (2^n seconds) for retrying on `StorageQuotaExceededError`, with configurable max retries (default 4)
  - Retries only on quota errors; other exceptions propagate immediately
  - Backoff sequence: 2s, 4s, 8s, 16s for max_retries=4
  - Logs warning messages with retry attempt information
- **Updated `generate_slides()` workflow**: Replaced direct `copy_presentation()` calls with `copy_presentation_with_quota_retry()` for both named and anonymous presentation copies
- **Comprehensive test coverage**: Added 6 test cases covering success paths, single/multiple retries, exponential backoff verification, max retries exhaustion, and non-quota error propagation

## Implementation Details
- Uses `time.sleep()` for backoff delays
- Maintains the same function signature and return type as the original `copy_presentation()`
- Includes an unreachable assertion at the end for code clarity (marked with pragma: no cover)
- Gracefully handles the case where quota errors occur after trash is emptied by giving the quota system time to propagate updates

https://claude.ai/code/session_01G47NDsSsVc6qg9RtZD25Ad