### PR TITLE
Fix invalid AutofitType: use TEXT_AUTOFIT instead of SHRINK_TEXT_ON_O…

### DIFF
--- a/tests/test_image_handling.py
+++ b/tests/test_image_handling.py
@@ -309,18 +309,18 @@ class TestBodyResizeRequests:
         assert len(reqs) == 2
 
     def test_autofit_shrink_on_overflow_applied(self):
-        """Second request must set SHRINK_TEXT_ON_OVERFLOW on the body element."""
+        """Second request must set TEXT_AUTOFIT on the body element."""
         reqs = _body_resize_requests(self._ELEMS, has_images=False)
         autofit_req = reqs[1]["updateShapeProperties"]
         assert autofit_req["objectId"] == "body_elem"
-        assert autofit_req["shapeProperties"]["autofit"]["autofitType"] == "SHRINK_TEXT_ON_OVERFLOW"
+        assert autofit_req["shapeProperties"]["autofit"]["autofitType"] == "TEXT_AUTOFIT"
         assert autofit_req["fields"] == "autofit.autofitType"
 
     def test_autofit_applied_with_images_too(self):
-        """SHRINK_TEXT_ON_OVERFLOW must also be set when images are present."""
+        """TEXT_AUTOFIT must also be set when images are present."""
         reqs = _body_resize_requests(self._ELEMS, has_images=True)
         autofit_req = reqs[1]["updateShapeProperties"]
-        assert autofit_req["shapeProperties"]["autofit"]["autofitType"] == "SHRINK_TEXT_ON_OVERFLOW"
+        assert autofit_req["shapeProperties"]["autofit"]["autofitType"] == "TEXT_AUTOFIT"
 
     def test_request_targets_body_element(self):
         req = _body_resize_requests(self._ELEMS, has_images=False)[0]

--- a/weekly_slides_bot.py
+++ b/weekly_slides_bot.py
@@ -771,7 +771,7 @@ def _body_resize_requests(page_elements: list[dict], has_images: bool) -> list[d
     *has_images* is True the body text box is constrained to the left portion
     of the slide so that it does not overlap with images on the right.
 
-    A ``SHRINK_TEXT_ON_OVERFLOW`` autofit property is also applied so that
+    A ``TEXT_AUTOFIT`` autofit property is also applied so that
     long submissions shrink their text to fit within the box rather than
     overflowing and obscuring other elements.
     """
@@ -809,12 +809,12 @@ def _body_resize_requests(page_elements: list[dict], has_images: bool) -> list[d
             "updateShapeProperties": {
                 "objectId": elem["objectId"],
                 "shapeProperties": {
-                    # SHRINK_TEXT_ON_OVERFLOW is a Google Slides API autofit mode
+                    # TEXT_AUTOFIT is a Google Slides API autofit mode
                     # that automatically reduces the font size when the text content
                     # exceeds the shape's boundaries, preventing overlap with adjacent
                     # images or the author bar.
                     "autofit": {
-                        "autofitType": "SHRINK_TEXT_ON_OVERFLOW",
+                        "autofitType": "TEXT_AUTOFIT",
                     }
                 },
                 "fields": "autofit.autofitType",


### PR DESCRIPTION
…VERFLOW

SHRINK_TEXT_ON_OVERFLOW is not a valid Google Slides API AutofitType enum value, causing a 400 error on batchUpdate calls. The correct value for shrinking text to fit a shape is TEXT_AUTOFIT.

https://claude.ai/code/session_016Rsh5MU6YwDZQUtdATNP3S