### PR TITLE
Fix Monday preview not detecting new announcement round

### DIFF
--- a/tests/test_mod_channel.py
+++ b/tests/test_mod_channel.py
@@ -1207,6 +1207,7 @@ class TestPreviewModeRouting:
     @patch(
         "weekly_slides_bot.load_state",
         return_value={
+            "marker_id": "100",
             "named_pres_id": "existing_named",
             "anon_pres_id": "existing_anon",
             "topic": "Old Topic",
@@ -1214,7 +1215,7 @@ class TestPreviewModeRouting:
     )
     async def test_preview_posts_existing_decks_when_no_submissions(self, _load):
         """Preview mode should post existing deck links from state even when
-        there are no SUBMISSION messages at all."""
+        there are no SUBMISSION messages at all (same round)."""
         from weekly_slides_bot import generate_slides
 
         marker_msg = MagicMock()
@@ -1232,10 +1233,42 @@ class TestPreviewModeRouting:
     @pytest.mark.asyncio
     @patch("weekly_slides_bot.BOT_MODE", "preview")
     @patch("weekly_slides_bot.DISCORD_MOD_CHANNEL_ID", 3)
+    @patch(
+        "weekly_slides_bot.load_state",
+        return_value={
+            "marker_id": "50",
+            "named_pres_id": "existing_named",
+            "anon_pres_id": "existing_anon",
+            "topic": "Old Topic",
+        },
+    )
+    async def test_preview_new_round_no_submissions_posts_notice(self, _load):
+        """Preview mode should notify the mod channel about a new round
+        instead of re-posting stale deck links from the old round."""
+        from weekly_slides_bot import generate_slides
+
+        marker_msg = MagicMock()
+        marker_msg.id = 100
+        marker_msg.content = "GUESS CHAT New Topic"
+
+        mock_client, mock_results_channel, mock_mod_channel = (
+            self._make_client_with_marker_no_submissions(marker_msg)
+        )
+        await generate_slides(mock_client)
+
+        mock_mod_channel.send.assert_called_once()
+        sent_text = mock_mod_channel.send.call_args[0][0]
+        assert "New Topic" in sent_text
+        assert "No submissions yet" in sent_text
+        mock_results_channel.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("weekly_slides_bot.BOT_MODE", "preview")
+    @patch("weekly_slides_bot.DISCORD_MOD_CHANNEL_ID", 3)
     @patch("weekly_slides_bot.load_state", return_value={})
-    async def test_preview_no_submissions_no_state_does_not_post(self, _load):
-        """Preview mode with no submissions and no existing decks in state
-        should not post anything (nothing to show)."""
+    async def test_preview_no_submissions_no_state_posts_new_round_notice(self, _load):
+        """Preview mode with no submissions and no state should post a
+        new-round notice (empty state means the marker is always new)."""
         from weekly_slides_bot import generate_slides
 
         marker_msg = MagicMock()
@@ -1247,5 +1280,7 @@ class TestPreviewModeRouting:
         )
         await generate_slides(mock_client)
 
-        mock_mod_channel.send.assert_not_called()
+        mock_mod_channel.send.assert_called_once()
+        sent_text = mock_mod_channel.send.call_args[0][0]
+        assert "No submissions yet" in sent_text
         mock_results_channel.send.assert_not_called()

--- a/weekly_slides_bot.py
+++ b/weekly_slides_bot.py
@@ -1635,8 +1635,12 @@ async def generate_slides(client: discord.Client) -> None:
 
     if not all_submissions:
         # In preview/test_slides mode, re-post the existing deck links from state so
-        # that the pipeline can always be verified.
-        if BOT_MODE in ("preview", "test_slides") and state.get("named_pres_id"):
+        # that the pipeline can always be verified.  However, if the marker has
+        # changed (new round), the old decks are stale — notify the mod channel
+        # about the new topic instead of re-posting irrelevant links.
+        prev_marker_id = state.get("marker_id")
+        is_new_round = prev_marker_id != marker_id
+        if BOT_MODE in ("preview", "test_slides") and state.get("named_pres_id") and not is_new_round:
             print("[info] No SUBMISSION messages found — re-posting existing deck links.")
             named_pres_id = state["named_pres_id"]
             anon_pres_id = state["anon_pres_id"]
@@ -1653,6 +1657,21 @@ async def generate_slides(client: discord.Client) -> None:
                     msg_text = format_results_message(post_topic, [], named_url, anon_url)
                     await post_channel.send(msg_text)
                     print("[info] Posted results to channel.")
+            return
+        if BOT_MODE in ("preview", "test_slides") and is_new_round:
+            print(f"[info] New round detected (topic: '{topic}') but no submissions yet.")
+            if BOT_MODE == "test_slides":
+                notify_channel_id = DISCORD_TEST_CHANNEL_ID
+            else:
+                notify_channel_id = DISCORD_MOD_CHANNEL_ID
+            if notify_channel_id is not None:
+                notify_channel = client.get_channel(notify_channel_id)
+                if notify_channel is not None:
+                    await notify_channel.send(
+                        f"New Guess Chat round detected: **{topic}**\n"
+                        f"No submissions yet — will generate slides once submissions arrive."
+                    )
+                    print("[info] Posted new-round notice to channel.")
             return
         print("[info] No SUBMISSION messages found after the marker.")
         return


### PR DESCRIPTION
The "no submissions" early-return path in generate_slides() ran before
the new-round detection (marker_id comparison).  When the Monday preview
found the new announcement but no submissions existed yet, it blindly
re-posted stale deck links from the previous round's state instead of
recognising the new topic.

Now the preview checks whether the marker has changed before re-posting
old deck links.  For a new round with no submissions it posts a notice
to the mod channel with the new topic name.

https://claude.ai/code/session_01KNTiD9569ETn7RmYJzQsZR