### PR TITLE
Retry transient SSL/connection errors in execute_with_retry

### DIFF
--- a/tests/test_execute_retry.py
+++ b/tests/test_execute_retry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import ssl
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -166,3 +167,73 @@ class TestExecuteWithRetryRefreshError:
         captured = capsys.readouterr()
         assert "credential refresh failed" in captured.out
         assert "GOOGLE_OAUTH_TOKEN" in captured.out
+
+
+class TestExecuteWithRetryConnectionErrors:
+    """Transient connection/SSL errors are retried with backoff."""
+
+    @patch("weekly_slides_bot.time.sleep")
+    def test_retries_on_ssl_eof_error(self, mock_sleep):
+        request = MagicMock()
+        request.execute.side_effect = [
+            ssl.SSLEOFError("EOF occurred in violation of protocol (_ssl.c:2427)"),
+            {"ok": True},
+        ]
+        result = execute_with_retry(request)
+        assert result == {"ok": True}
+        assert request.execute.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("weekly_slides_bot.time.sleep")
+    def test_retries_on_ssl_error(self, mock_sleep):
+        request = MagicMock()
+        request.execute.side_effect = [
+            ssl.SSLError("SSL handshake failed"),
+            {"ok": True},
+        ]
+        result = execute_with_retry(request)
+        assert result == {"ok": True}
+        assert request.execute.call_count == 2
+
+    @patch("weekly_slides_bot.time.sleep")
+    def test_retries_on_connection_reset_error(self, mock_sleep):
+        request = MagicMock()
+        request.execute.side_effect = [
+            ConnectionResetError("Connection reset by peer"),
+            {"ok": True},
+        ]
+        result = execute_with_retry(request)
+        assert result == {"ok": True}
+        assert request.execute.call_count == 2
+
+    @patch("weekly_slides_bot.time.sleep")
+    def test_retries_on_connection_error(self, mock_sleep):
+        request = MagicMock()
+        request.execute.side_effect = [
+            ConnectionError("Connection refused"),
+            {"ok": True},
+        ]
+        result = execute_with_retry(request)
+        assert result == {"ok": True}
+        assert request.execute.call_count == 2
+
+    @patch("weekly_slides_bot.time.sleep")
+    def test_raises_after_max_retries_on_ssl_error(self, mock_sleep):
+        request = MagicMock()
+        request.execute.side_effect = ssl.SSLEOFError("EOF occurred")
+        with pytest.raises(ssl.SSLEOFError):
+            execute_with_retry(request, max_retries=3)
+        assert request.execute.call_count == 4  # 1 initial + 3 retries
+        assert mock_sleep.call_count == 3
+
+    @patch("weekly_slides_bot.time.sleep")
+    def test_prints_warning_on_connection_error(self, mock_sleep, capsys):
+        request = MagicMock()
+        request.execute.side_effect = [
+            ssl.SSLEOFError("EOF occurred"),
+            {"ok": True},
+        ]
+        execute_with_retry(request)
+        captured = capsys.readouterr()
+        assert "Transient connection error" in captured.out
+        assert "retrying" in captured.out

--- a/weekly_slides_bot.py
+++ b/weekly_slides_bot.py
@@ -18,6 +18,7 @@ import json
 import os
 import random
 import re
+import ssl
 import time
 import traceback
 import zoneinfo
@@ -329,6 +330,16 @@ def execute_with_retry(request, max_retries: int = 5) -> Any:
                 wait = (2 ** attempt) + random.random()
                 print(
                     f"[warn] Google API error (HTTP {status}); "
+                    f"retrying in {wait:.1f}s (attempt {attempt + 1}/{max_retries})"
+                )
+                time.sleep(wait)
+            else:
+                raise
+        except (ssl.SSLEOFError, ssl.SSLError, ConnectionError, OSError) as exc:
+            if attempt < max_retries:
+                wait = (2 ** attempt) + random.random()
+                print(
+                    f"[warn] Transient connection error: {exc!r}; "
                     f"retrying in {wait:.1f}s (attempt {attempt + 1}/{max_retries})"
                 )
                 time.sleep(wait)


### PR DESCRIPTION
The bot was crashing with SSLEOFError during Google Drive image uploads (issue #86). Add a catch for ssl.SSLEOFError, ssl.SSLError, ConnectionError, and OSError in execute_with_retry so these transient network failures are retried with exponential backoff, matching the existing behaviour for HTTP 500/502/503 errors.

Closes #86

https://claude.ai/code/session_01TsrysNh4jnzEC8EqJ3LhqM