### PR TITLE
Send a User-Agent on Discord and GitHub API calls

### DIFF
--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -372,6 +372,35 @@ def test_read_state_handles_an_empty_file():
         assert interactions.read_state() == {}
 
 
+def _sent_request(urlopen_mock):
+    return urlopen_mock.call_args.args[0]
+
+
+def test_github_requests_identify_themselves():
+    """GitHub rejects requests that send no User-Agent."""
+    with patch("urllib.request.urlopen") as urlopen:
+        urlopen.return_value.__enter__.return_value.read.return_value = b""
+        interactions._github_request("POST", "/repos/o/r/x", {"a": 1})
+
+    assert _sent_request(urlopen).get_header("User-agent")
+
+
+def test_discord_requests_use_the_required_bot_agent():
+    """Discord's edge 403s urllib's default Python-urllib agent."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "vercel"))
+    with patch.dict(
+        "os.environ",
+        {"DISCORD_APPLICATION_ID": "1", "DISCORD_TOKEN": "t", "DISCORD_GUILD_ID": "2"},
+    ):
+        import register_commands
+
+    with patch("urllib.request.urlopen") as urlopen:
+        urlopen.return_value.__enter__.return_value.read.return_value = b"[]"
+        register_commands.put_commands([])
+
+    assert _sent_request(urlopen).get_header("User-agent").startswith("DiscordBot ")
+
+
 # ---------------------------------------------------------------------------
 # The HTTP handler end to end
 # ---------------------------------------------------------------------------

--- a/vercel/api/interactions.py
+++ b/vercel/api/interactions.py
@@ -110,6 +110,8 @@ def _github_request(method: str, path: str, payload: dict | None = None) -> dict
     req.add_header("Accept", "application/vnd.github+json")
     req.add_header("Authorization", f"Bearer {GH_DISPATCH_TOKEN}")
     req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    # GitHub requires every request to identify itself.
+    req.add_header("User-Agent", "guess-chat-bot-interactions")
     if data is not None:
         req.add_header("Content-Type", "application/json")
     with urllib.request.urlopen(req, timeout=_GITHUB_TIMEOUT_S) as resp:

--- a/vercel/register_commands.py
+++ b/vercel/register_commands.py
@@ -34,6 +34,10 @@ BOOLEAN = 5
 # client-side affordance.
 MANAGE_GUILD = "32"
 
+# Discord's edge rejects urllib's default "Python-urllib/x.y" agent with a 403,
+# so every request has to identify itself the way the API docs require.
+USER_AGENT = "DiscordBot (https://github.com/theReuben/guess-chat-bot, 1.0)"
+
 MODES = ("preview", "slides", "announce", "test_slides", "test_announce")
 _MODE_CHOICES = [{"name": mode, "value": mode} for mode in MODES]
 
@@ -110,6 +114,7 @@ def put_commands(commands: list[dict]) -> list[dict]:
     req = urllib.request.Request(url, data=json.dumps(commands).encode(), method="PUT")
     req.add_header("Authorization", f"Bot {BOT_TOKEN}")
     req.add_header("Content-Type", "application/json")
+    req.add_header("User-Agent", USER_AGENT)
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             return json.loads(resp.read())


### PR DESCRIPTION
Discord's edge rejects urllib's default Python-urllib/3.12 agent with a 403 before the request reaches the API, so register_commands.py could never have registered anything. Verified against the live endpoint: the default agent gets 403, DiscordBot gets 401 for a bad token.

GitHub accepts the default but documents a User-Agent as required, so the interactions endpoint now sends one too.