### PR TITLE
Add /guesschat announce and /guesschat time (strim mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Discord requires a reply within **3 seconds** and a deck build takes minutes, so
 | Command | Effect |
 |---|---|
 | `/guesschat preview` | Rebuild the decks and post to the mod channel |
+| `/guesschat announce` | Post the `GUESS CHAT` announcement to the submissions channel (pings `@everyone`) |
 | `/guesschat marker message_id:<id> [mode]` | Adopt an announcement someone else posted — see [Announcement Override](#announcement-override) |
 | `/guesschat run mode:<mode> [marker_message_id] [force_reset]` | Full control over every workflow input |
 | `/guesschat status` | Current round, marker, processed count and deck links (private reply) |

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -135,8 +135,9 @@ def test_dm_invocation_is_refused_when_a_role_is_required():
 # ---------------------------------------------------------------------------
 
 
-def test_preview_maps_to_preview_mode():
-    assert interactions.build_inputs("preview", {}) == ({"bot_mode": "preview"}, None)
+@pytest.mark.parametrize("name", ["preview", "announce"])
+def test_shortcut_subcommands_map_to_the_mode_they_are_named_after(name):
+    assert interactions.build_inputs(name, {}) == ({"bot_mode": name}, None)
 
 
 def test_marker_defaults_to_preview_mode():
@@ -258,6 +259,21 @@ def test_a_command_dispatches_the_workflow_and_confirms(allowed):
     assert "preview" in reply["data"]["content"]
     # Run confirmations stay visible so the mod channel keeps a record.
     assert "flags" not in reply["data"]
+
+
+def test_announce_dispatches_and_warns_that_it_posts_publicly(allowed):
+    with patch.object(interactions, "dispatch_workflow") as dispatch:
+        reply = interactions.handle_command(_command("announce"))
+
+    dispatch.assert_called_once_with({"bot_mode": "announce"})
+    assert "submissions channel" in reply["data"]["content"]
+
+
+def test_only_announce_carries_the_public_post_warning(allowed):
+    with patch.object(interactions, "dispatch_workflow"):
+        reply = interactions.handle_command(_command("preview"))
+
+    assert "submissions channel" not in reply["data"]["content"]
 
 
 def test_force_reset_is_called_out_in_the_confirmation(allowed):

--- a/vercel/api/interactions.py
+++ b/vercel/api/interactions.py
@@ -170,11 +170,14 @@ def _workflow_url() -> str:
 
 
 def _started_message(inputs: dict[str, str]) -> str:
-    lines = [f"▶️ Started a **{inputs['bot_mode']}** run."]
+    mode = inputs["bot_mode"]
+    lines = [f"▶️ Started the bot in **{mode}** mode."]
     if inputs.get("marker_message_id"):
         lines.append(
             f"Using message `{inputs['marker_message_id']}` as the announcement."
         )
+    if mode == "announce":
+        lines.append("📣 This posts the announcement to the submissions channel.")
     if inputs.get("force_reset") == "true":
         lines.append("⚠️ State wiped — brand-new decks will be created.")
     lines.append(f"Results will be posted when it finishes · <{_workflow_url()}>")
@@ -193,8 +196,9 @@ def build_inputs(name: str, options: dict) -> tuple[dict[str, str] | None, str |
     Returns ``(inputs, None)`` on success or ``(None, reason)`` when the
     options don't make sense.
     """
-    if name == "preview":
-        return {"bot_mode": "preview"}, None
+    # Shortcut subcommands whose name is simply the mode they run.
+    if name in ("preview", "announce"):
+        return {"bot_mode": name}, None
 
     if name == "marker":
         message_id = str(options.get("message_id") or "").strip()

--- a/vercel/register_commands.py
+++ b/vercel/register_commands.py
@@ -54,6 +54,11 @@ COMMANDS = [
             },
             {
                 "type": SUB_COMMAND,
+                "name": "announce",
+                "description": "Post the GUESS CHAT announcement to the submissions channel (@everyone)",
+            },
+            {
+                "type": SUB_COMMAND,
                 "name": "marker",
                 "description": "Use an announcement someone else posted as this round's marker",
                 "options": [


### PR DESCRIPTION
Two new shortcut subcommands.

## `/guesschat announce`

Was only reachable via `/guesschat run mode:announce`. It's a routine weekly action, so it gets a shortcut the way `preview` does.

## `/guesschat time` — new `strim` bot mode

"Guess chat time": one no-argument command that generates the decks and posts them to **`#strim-tim`** (`1054729620844453898`), where the round actually gets played.

`strim` is a **real run**, not a preview:

| | Behaviour |
|---|---|
| Builds/appends decks | Yes, same pipeline as Friday |
| Saves state | **Yes** — consumes the round |
| Friday 11:30 afterwards | Finds nothing new, stays quiet |
| Run it a second time | Re-posts the existing deck links rather than going silent |

Consuming the round is deliberate: `#strim-tim` becomes where results land, and the scheduled Friday post to the results channel steps aside. Re-running is safe, which matters for a command fired live mid-stream.

This deliberately avoids the `test_slides` flaw, where skipping persistence means the same submissions get appended again on the next run and the deck ends up with duplicate slides.

## Tidying that came with it

Adding a fourth mode made two existing patterns worth naming rather than repeating:

- The two identical `if BOT_MODE == "test_slides": … else: …` channel pairs became `notice_channel_id()`.
- `("preview", "test_slides")` appeared at three call sites meaning "keeps posting when there's nothing new". It's now `REPOSTING_MODES`, with a comment on why `slides` is deliberately excluded — the Friday run must stay silent when it has nothing to say.

Confirmation wording also improved: "Started a **announce** run" → "Started the bot in **announce** mode", and `announce`/`strim` each name their destination, the way `force_reset` already warns about wiping state.

## Testing

346 pass. New `tests/test_strim_mode.py` covers the routing and the three behaviours above — results reaching `#strim-tim` and *not* the results channel, state being persisted, and a re-run re-posting links without touching the decks. Plus a missing `DISCORD_STRIM_CHANNEL_ID` skipping the post rather than crashing, so a config slip can't lose a round.

## Already done outside this PR

- `DISCORD_STRIM_CHANNEL_ID` secret set on the repo
- Commands re-registered: `/guesschat (preview, time, announce, marker, run, status)`

Both take effect independently of this merge, but the endpoint can't serve `time` or `announce` until Vercel redeploys from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
